### PR TITLE
Feat : 심리 다이어리 & 캘린더 기능 구현 (#18)

### DIFF
--- a/src/main/java/com/ayu/dadokim/business/counseling/controller/ChatController.java
+++ b/src/main/java/com/ayu/dadokim/business/counseling/controller/ChatController.java
@@ -28,13 +28,10 @@ import java.util.List;
 public class ChatController {
 
     private final ChatService chatService;
-    private final UserService userService;
 
-    public ChatController(ChatService chatService, UserService userService) {
+    public ChatController(ChatService chatService) {
         this.chatService = chatService;
-        this.userService = userService;
     }
-
     /**
      * 💬 새 상담 메시지 전송 및 AI 응답 반환
      * ----------------------------------
@@ -56,7 +53,7 @@ public class ChatController {
      */
     @PostMapping
     public ChatResponseDTO chat(@RequestBody ChatRequestDTO request) throws IOException {
-        String reply = chatService.getChatResponse(userService.readUser(), request);
+        String reply = chatService.getChatResponse(request);
         return new ChatResponseDTO("assistant", reply);
     }
 
@@ -75,7 +72,7 @@ public class ChatController {
      */
     @GetMapping("/history/all")
     public List<ChatMessage> getFullChatHistory() {
-        return chatService.getFullChatHistory(userService.readUser());
+        return chatService.getFullChatHistory();
     }
 
     /**
@@ -101,6 +98,6 @@ public class ChatController {
             @RequestParam("startDate") LocalDateTime startDate,
             @RequestParam("endDate") LocalDateTime endDate
     ) {
-        return chatService.getChatHistoryByDateRange(userService.readUser(), startDate, endDate);
+        return chatService.getChatHistoryByDateRange(startDate, endDate);
     }
 }

--- a/src/main/java/com/ayu/dadokim/business/counseling/controller/GeminiController.java
+++ b/src/main/java/com/ayu/dadokim/business/counseling/controller/GeminiController.java
@@ -16,11 +16,9 @@ import java.util.List;
 public class GeminiController {
 
     private final GeminiService geminiService;
-    private final UserService userService;
 
-    public GeminiController(GeminiService geminiService, UserService userService) {
+    public GeminiController(GeminiService geminiService) {
         this.geminiService = geminiService;
-        this.userService = userService;
     }
 
     /**
@@ -38,7 +36,7 @@ public class GeminiController {
      */
     @PostMapping
     public ChatResponseDTO chat(@RequestBody ChatRequestDTO request) throws IOException {
-        return geminiService.getChatResponse(userService.readUser(), request);
+        return geminiService.getChatResponse(request);
     }
 
     /**
@@ -53,7 +51,7 @@ public class GeminiController {
      */
     @GetMapping("/history/all")
     public List<ChatMessage> getFullChatHistory() {
-        return geminiService.getFullChatHistory(userService.readUser());
+        return geminiService.getFullChatHistory();
     }
 
     /**
@@ -73,6 +71,6 @@ public class GeminiController {
             @RequestParam("startDate") LocalDateTime startDate,
             @RequestParam("endDate") LocalDateTime endDate
     ) {
-        return geminiService.getChatHistoryByDateRange(userService.readUser(), startDate, endDate);
+        return geminiService.getChatHistoryByDateRange(startDate, endDate);
     }
 }

--- a/src/main/java/com/ayu/dadokim/business/counseling/service/ChatService.java
+++ b/src/main/java/com/ayu/dadokim/business/counseling/service/ChatService.java
@@ -11,6 +11,7 @@ import jakarta.transaction.Transactional;
 import okhttp3.*;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -44,11 +45,15 @@ public class ChatService {
      * user별로 대화 기록을 저장합니다.
      */
     @Transactional
-    public String getChatResponse(UserResponse userResponse, ChatRequestDTO request) throws IOException {
+    public String getChatResponse(ChatRequestDTO request) throws IOException {
 
         // ① 유저 조회 (유효성 검사)
-        UserEntity user = userRepository.findByEmail(userResponse.email())
-                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자입니다."));
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        UserEntity user = userRepository.findByUsernameAndIsLock(username, false)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+//        UserEntity user = userRepository.findByEmail(userResponse.email())
+//                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자입니다."));
 
         // ② 해당 유저의 이전 대화 불러오기 (null-safe)
         List<ChatMessage> history = Optional
@@ -129,9 +134,11 @@ public class ChatService {
     /**
      * user별 특정 기간 대화 조회 (빈 리스트 방어)
      */
-    public List<ChatMessage> getChatHistoryByDateRange(UserResponse userResponse, LocalDateTime startDate, LocalDateTime endDate) {
-        UserEntity user = userRepository.findByEmail(userResponse.email())
-                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자입니다."));
+    public List<ChatMessage> getChatHistoryByDateRange(LocalDateTime startDate, LocalDateTime endDate) {
+        // ① 유저 조회 (유효성 검사)
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        UserEntity user = userRepository.findByUsernameAndIsLock(username, false)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
         return Optional
                 .ofNullable(chatMessageRepository.findByUserAndCreatedDateBetweenOrderByCreatedDateAsc(user, startDate, endDate))
                 .orElseGet(ArrayList::new);
@@ -140,9 +147,12 @@ public class ChatService {
     /**
      * user별 전체 대화 조회 (빈 리스트 방어)
      */
-    public List<ChatMessage> getFullChatHistory(UserResponse userResponse) {
-        UserEntity user = userRepository.findByEmail(userResponse.email())
-                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자입니다."));
+    public List<ChatMessage> getFullChatHistory() {
+        // ① 유저 조회 (유효성 검사)
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        UserEntity user = userRepository.findByUsernameAndIsLock(username, false)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
         return Optional
                 .ofNullable(chatMessageRepository.findByUserOrderByCreatedDateAsc(user))
                 .orElseGet(ArrayList::new);

--- a/src/main/java/com/ayu/dadokim/business/counseling/service/GeminiService.java
+++ b/src/main/java/com/ayu/dadokim/business/counseling/service/GeminiService.java
@@ -15,6 +15,7 @@ import com.ayu.dadokim.business.user.form.UserEntity;
 import com.ayu.dadokim.business.user.repository.UserRepository;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,11 +55,12 @@ public class GeminiService {
      * @return Gemini 모델의 답변
      * @throws IOException API 통신 오류 발생 시
      */
-    public ChatResponseDTO getChatResponse(UserResponse userResponse, ChatRequestDTO request) throws IOException {
+    public ChatResponseDTO getChatResponse(ChatRequestDTO request) throws IOException {
 
-        // ① userId 기반 사용자 정보 조회
-        UserEntity user = userRepository.findByEmail(userResponse.email())
-                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자입니다."));
+        // ① 유저 조회 (유효성 검사)
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        UserEntity user = userRepository.findByUsernameAndIsLock(username, false)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
         JSONArray contentsArray = new JSONArray();
 
@@ -167,18 +169,24 @@ public class GeminiService {
     /**
      * 특정 사용자(userId)의 지정된 기간 동안의 상담 기록 조회
      */
-    public List<ChatMessage> getChatHistoryByDateRange(UserResponse userResponse, LocalDateTime startDate, LocalDateTime endDate) {
-        UserEntity user = userRepository.findByEmail(userResponse.email())
-                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자입니다."));
+    public List<ChatMessage> getChatHistoryByDateRange(LocalDateTime startDate, LocalDateTime endDate) {
+        // ① 유저 조회 (유효성 검사)
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        UserEntity user = userRepository.findByUsernameAndIsLock(username, false)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
         return chatMessageRepository.findByUserAndCreatedDateBetweenOrderByCreatedDateAsc(user, startDate, endDate);
     }
 
     /**
      * 특정 사용자(userId)의 전체 상담 대화 기록 조회
      */
-    public List<ChatMessage> getFullChatHistory(UserResponse userResponse) {
-        UserEntity user = userRepository.findByEmail(userResponse.email())
-                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자입니다."));
+    public List<ChatMessage> getFullChatHistory() {
+        // ① 유저 조회 (유효성 검사)
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        UserEntity user = userRepository.findByUsernameAndIsLock(username, false)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
         return Optional
                 .ofNullable(chatMessageRepository.findByUserOrderByCreatedDateAsc(user))
                 .orElseGet(ArrayList::new); // 빈 리스트 방어

--- a/src/main/java/com/ayu/dadokim/business/diary/controller/DiaryController.java
+++ b/src/main/java/com/ayu/dadokim/business/diary/controller/DiaryController.java
@@ -1,6 +1,9 @@
 package com.ayu.dadokim.business.diary.controller;
 
 import com.ayu.dadokim.business.diary.form.DiaryEntity;
+import com.ayu.dadokim.business.diary.form.request.DiaryRequest;
+import com.ayu.dadokim.business.diary.form.response.DiaryListResponse;
+import com.ayu.dadokim.business.diary.form.response.DiaryResponse;
 import com.ayu.dadokim.business.diary.service.DiaryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -19,58 +22,26 @@ public class DiaryController {
 
     private final DiaryService diaryService;
 
-    /**
-     * ✅ 일기 저장 또는 수정
-     * POST /api/diary
-     */
+    /** ✅ 일기 저장 또는 수정 */
     @PostMapping
-    public ResponseEntity<Map<String, Object>> saveDiary(@RequestBody Map<String, String> body) {
-        LocalDate date = LocalDate.parse(body.get("date"));
-        String text = body.get("diaryText");
-        DiaryEntity diary = diaryService.saveDiary(date, text);
-
-        return ResponseEntity.ok(Map.of(
-                "id", diary.getId(),
-                "date", diary.getDate(),
-                "diaryText", diary.getDiaryText()
-        ));
-    }
-
-    /**
-     * ✅ 특정 날짜 일기 조회
-     * GET /api/diary?date=2025-01-03
-     */
-    @GetMapping
-    public ResponseEntity<Map<String, Object>> getDiary(
-            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
-
-        DiaryEntity diary = diaryService.getDiary(date);
-        if (diary == null)
-            return ResponseEntity.ok(Map.of("exists", false));
-
-        return ResponseEntity.ok(Map.of(
-                "exists", true,
-                "date", diary.getDate(),
-                "diaryText", diary.getDiaryText()
-        ));
-    }
-
-    /**
-     * ✅ 전체 일기 목록 조회
-     * GET /api/diary/list
-     */
-    @GetMapping("/list")
-    public ResponseEntity<List<Map<String, Object>>> getAllDiaries() {
-        List<DiaryEntity> diaries = diaryService.getAllDiaries();
-
-        List<Map<String, Object>> response = diaries.stream()
-                .map(d -> Map.<String, Object>of(
-                        "date", d.getDate(),
-                        "diaryText", d.getDiaryText()
-                ))
-                .collect(Collectors.toList());
-
+    public ResponseEntity<DiaryResponse> saveDiary(@RequestBody DiaryRequest request) {
+        DiaryResponse response = diaryService.saveDiary(request);
         return ResponseEntity.ok(response);
     }
 
+    /** ✅ 특정 날짜 일기 조회 */
+    @GetMapping
+    public ResponseEntity<DiaryResponse> getDiary(
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+
+        DiaryResponse response = diaryService.getDiary(date);
+        return ResponseEntity.ok(response);
+    }
+
+    /** ✅ 전체 일기 목록 조회 */
+    @GetMapping("/list")
+    public ResponseEntity<List<DiaryListResponse>> getAllDiaries() {
+        List<DiaryListResponse> responses = diaryService.getAllDiaries();
+        return ResponseEntity.ok(responses);
+    }
 }

--- a/src/main/java/com/ayu/dadokim/business/diary/controller/DiaryController.java
+++ b/src/main/java/com/ayu/dadokim/business/diary/controller/DiaryController.java
@@ -8,7 +8,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/diary")
@@ -20,7 +22,6 @@ public class DiaryController {
     /**
      * ✅ 일기 저장 또는 수정
      * POST /api/diary
-     * body: { "date": "2025-01-03", "diaryText": "오늘은 좋은 날씨였다." }
      */
     @PostMapping
     public ResponseEntity<Map<String, Object>> saveDiary(@RequestBody Map<String, String> body) {
@@ -53,4 +54,23 @@ public class DiaryController {
                 "diaryText", diary.getDiaryText()
         ));
     }
+
+    /**
+     * ✅ 전체 일기 목록 조회
+     * GET /api/diary/list
+     */
+    @GetMapping("/list")
+    public ResponseEntity<List<Map<String, Object>>> getAllDiaries() {
+        List<DiaryEntity> diaries = diaryService.getAllDiaries();
+
+        List<Map<String, Object>> response = diaries.stream()
+                .map(d -> Map.<String, Object>of(
+                        "date", d.getDate(),
+                        "diaryText", d.getDiaryText()
+                ))
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/com/ayu/dadokim/business/diary/controller/DiaryController.java
+++ b/src/main/java/com/ayu/dadokim/business/diary/controller/DiaryController.java
@@ -1,0 +1,56 @@
+package com.ayu.dadokim.business.diary.controller;
+
+import com.ayu.dadokim.business.diary.form.DiaryEntity;
+import com.ayu.dadokim.business.diary.service.DiaryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/diary")
+@RequiredArgsConstructor
+public class DiaryController {
+
+    private final DiaryService diaryService;
+
+    /**
+     * ✅ 일기 저장 또는 수정
+     * POST /api/diary
+     * body: { "date": "2025-01-03", "diaryText": "오늘은 좋은 날씨였다." }
+     */
+    @PostMapping
+    public ResponseEntity<Map<String, Object>> saveDiary(@RequestBody Map<String, String> body) {
+        LocalDate date = LocalDate.parse(body.get("date"));
+        String text = body.get("diaryText");
+        DiaryEntity diary = diaryService.saveDiary(date, text);
+
+        return ResponseEntity.ok(Map.of(
+                "id", diary.getId(),
+                "date", diary.getDate(),
+                "diaryText", diary.getDiaryText()
+        ));
+    }
+
+    /**
+     * ✅ 특정 날짜 일기 조회
+     * GET /api/diary?date=2025-01-03
+     */
+    @GetMapping
+    public ResponseEntity<Map<String, Object>> getDiary(
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+
+        DiaryEntity diary = diaryService.getDiary(date);
+        if (diary == null)
+            return ResponseEntity.ok(Map.of("exists", false));
+
+        return ResponseEntity.ok(Map.of(
+                "exists", true,
+                "date", diary.getDate(),
+                "diaryText", diary.getDiaryText()
+        ));
+    }
+}

--- a/src/main/java/com/ayu/dadokim/business/diary/form/DiaryEntity.java
+++ b/src/main/java/com/ayu/dadokim/business/diary/form/DiaryEntity.java
@@ -1,0 +1,31 @@
+package com.ayu.dadokim.business.diary.form;
+
+import com.ayu.dadokim.business.user.form.UserEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "diary")
+public class DiaryEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(columnDefinition = "TEXT")
+    private String diaryText;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+}

--- a/src/main/java/com/ayu/dadokim/business/diary/form/request/DiaryRequest.java
+++ b/src/main/java/com/ayu/dadokim/business/diary/form/request/DiaryRequest.java
@@ -1,0 +1,13 @@
+package com.ayu.dadokim.business.diary.form.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class DiaryRequest {
+
+    private LocalDate date;
+    private String diaryText;
+}

--- a/src/main/java/com/ayu/dadokim/business/diary/form/response/DiaryListResponse.java
+++ b/src/main/java/com/ayu/dadokim/business/diary/form/response/DiaryListResponse.java
@@ -1,0 +1,21 @@
+package com.ayu.dadokim.business.diary.form.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DiaryListResponse {
+    private LocalDate date;
+    private String diaryText;
+
+    public static DiaryListResponse fromEntity(com.ayu.dadokim.business.diary.form.DiaryEntity diary) {
+        return DiaryListResponse.builder()
+                .date(diary.getDate())
+                .diaryText(diary.getDiaryText())
+                .build();
+    }
+}

--- a/src/main/java/com/ayu/dadokim/business/diary/form/response/DiaryResponse.java
+++ b/src/main/java/com/ayu/dadokim/business/diary/form/response/DiaryResponse.java
@@ -1,0 +1,27 @@
+package com.ayu.dadokim.business.diary.form.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DiaryResponse {
+
+    private Long id;
+    private LocalDate date;
+    private String diaryText;
+    private boolean exists; // 단건 조회 시 존재 여부 표시용
+
+    public static DiaryResponse fromEntity(com.ayu.dadokim.business.diary.form.DiaryEntity diary) {
+        return DiaryResponse.builder()
+                .id(diary.getId())
+                .date(diary.getDate())
+                .diaryText(diary.getDiaryText())
+                .exists(true)
+                .build();
+    }
+}

--- a/src/main/java/com/ayu/dadokim/business/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/ayu/dadokim/business/diary/repository/DiaryRepository.java
@@ -3,9 +3,14 @@ package com.ayu.dadokim.business.diary.repository;
 import com.ayu.dadokim.business.diary.form.DiaryEntity;
 import com.ayu.dadokim.business.user.form.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface DiaryRepository extends JpaRepository<DiaryEntity, Long> {
     Optional<DiaryEntity> findByUserAndDate(UserEntity user, LocalDate date);
+
+    // ✅ 전체 일기 목록 조회용 쿼리
+    List<DiaryEntity> findAllByUser(UserEntity user);
 }

--- a/src/main/java/com/ayu/dadokim/business/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/ayu/dadokim/business/diary/repository/DiaryRepository.java
@@ -1,0 +1,11 @@
+package com.ayu.dadokim.business.diary.repository;
+
+import com.ayu.dadokim.business.diary.form.DiaryEntity;
+import com.ayu.dadokim.business.user.form.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface DiaryRepository extends JpaRepository<DiaryEntity, Long> {
+    Optional<DiaryEntity> findByUserAndDate(UserEntity user, LocalDate date);
+}

--- a/src/main/java/com/ayu/dadokim/business/diary/service/DiaryService.java
+++ b/src/main/java/com/ayu/dadokim/business/diary/service/DiaryService.java
@@ -1,0 +1,55 @@
+package com.ayu.dadokim.business.diary.service;
+
+import com.ayu.dadokim.business.diary.form.DiaryEntity;
+import com.ayu.dadokim.business.diary.repository.DiaryRepository;
+import com.ayu.dadokim.business.user.form.UserEntity;
+import com.ayu.dadokim.business.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class DiaryService {
+
+    private final DiaryRepository diaryRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 일기 저장 또는 수정
+     */
+    @Transactional
+    public DiaryEntity saveDiary(LocalDate date, String text) {
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        UserEntity user = userRepository.findByUsernameAndIsLock(username, false)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        return diaryRepository.findByUserAndDate(user, date)
+                .map(diary -> {
+                    diary.setDiaryText(text);
+                    return diaryRepository.save(diary);
+                })
+                .orElseGet(() -> diaryRepository.save(
+                        DiaryEntity.builder()
+                                .user(user)
+                                .date(date)
+                                .diaryText(text)
+                                .build()
+                ));
+    }
+
+    /**
+     * 특정 날짜의 일기 조회
+     */
+    @Transactional(readOnly = true)
+    public DiaryEntity getDiary(LocalDate date) {
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        UserEntity user = userRepository.findByUsernameAndIsLock(username, false)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        return diaryRepository.findByUserAndDate(user, date).orElse(null);
+    }
+}

--- a/src/main/java/com/ayu/dadokim/business/diary/service/DiaryService.java
+++ b/src/main/java/com/ayu/dadokim/business/diary/service/DiaryService.java
@@ -1,6 +1,9 @@
 package com.ayu.dadokim.business.diary.service;
 
 import com.ayu.dadokim.business.diary.form.DiaryEntity;
+import com.ayu.dadokim.business.diary.form.request.DiaryRequest;
+import com.ayu.dadokim.business.diary.form.response.DiaryListResponse;
+import com.ayu.dadokim.business.diary.form.response.DiaryResponse;
 import com.ayu.dadokim.business.diary.repository.DiaryRepository;
 import com.ayu.dadokim.business.user.form.UserEntity;
 import com.ayu.dadokim.business.user.repository.UserRepository;
@@ -11,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -20,43 +24,50 @@ public class DiaryService {
     private final UserRepository userRepository;
 
     @Transactional
-    public DiaryEntity saveDiary(LocalDate date, String text) {
+    public DiaryResponse saveDiary(DiaryRequest request) {
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        UserEntity user = userRepository.findByUsernameAndIsLock(username, false)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        DiaryEntity diary = diaryRepository.findByUserAndDate(user, request.getDate())
+                .map(d -> {
+                    d.setDiaryText(request.getDiaryText());
+                    return diaryRepository.save(d);
+                })
+                .orElseGet(() -> diaryRepository.save(
+                        DiaryEntity.builder()
+                                .user(user)
+                                .date(request.getDate())
+                                .diaryText(request.getDiaryText())
+                                .build()
+                ));
+
+        return DiaryResponse.fromEntity(diary);
+    }
+
+    @Transactional(readOnly = true)
+    public DiaryResponse getDiary(LocalDate date) {
         String username = SecurityContextHolder.getContext().getAuthentication().getName();
         UserEntity user = userRepository.findByUsernameAndIsLock(username, false)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
         return diaryRepository.findByUserAndDate(user, date)
-                .map(diary -> {
-                    diary.setDiaryText(text);
-                    return diaryRepository.save(diary);
-                })
-                .orElseGet(() -> diaryRepository.save(
-                        DiaryEntity.builder()
-                                .user(user)
-                                .date(date)
-                                .diaryText(text)
-                                .build()
-                ));
+                .map(DiaryResponse::fromEntity)
+                .orElse(DiaryResponse.builder()
+                        .exists(false)
+                        .date(date)
+                        .build());
     }
 
     @Transactional(readOnly = true)
-    public DiaryEntity getDiary(LocalDate date) {
+    public List<DiaryListResponse> getAllDiaries() {
         String username = SecurityContextHolder.getContext().getAuthentication().getName();
         UserEntity user = userRepository.findByUsernameAndIsLock(username, false)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-        return diaryRepository.findByUserAndDate(user, date).orElse(null);
-    }
-
-    /**
-     * ✅ 전체 일기 목록 조회
-     */
-    @Transactional(readOnly = true)
-    public List<DiaryEntity> getAllDiaries() {
-        String username = SecurityContextHolder.getContext().getAuthentication().getName();
-        UserEntity user = userRepository.findByUsernameAndIsLock(username, false)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
-
-        return diaryRepository.findAllByUser(user);
+        return diaryRepository.findAllByUser(user)
+                .stream()
+                .map(DiaryListResponse::fromEntity)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/ayu/dadokim/business/diary/service/DiaryService.java
+++ b/src/main/java/com/ayu/dadokim/business/diary/service/DiaryService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,9 +19,6 @@ public class DiaryService {
     private final DiaryRepository diaryRepository;
     private final UserRepository userRepository;
 
-    /**
-     * 일기 저장 또는 수정
-     */
     @Transactional
     public DiaryEntity saveDiary(LocalDate date, String text) {
         String username = SecurityContextHolder.getContext().getAuthentication().getName();
@@ -41,9 +39,6 @@ public class DiaryService {
                 ));
     }
 
-    /**
-     * 특정 날짜의 일기 조회
-     */
     @Transactional(readOnly = true)
     public DiaryEntity getDiary(LocalDate date) {
         String username = SecurityContextHolder.getContext().getAuthentication().getName();
@@ -51,5 +46,17 @@ public class DiaryService {
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
         return diaryRepository.findByUserAndDate(user, date).orElse(null);
+    }
+
+    /**
+     * ✅ 전체 일기 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public List<DiaryEntity> getAllDiaries() {
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        UserEntity user = userRepository.findByUsernameAndIsLock(username, false)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        return diaryRepository.findAllByUser(user);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
       dialect: org.hibernate.dialect.MySQLDialect
     properties:
       hibernate:


### PR DESCRIPTION
# 🚀 Description

## 📄 DiaryRequest 추가
- 클라이언트에서 일기 작성/수정 요청 시 사용하는 DTO
- 포함 필드:

```
LocalDate date  
String diaryText
```

## 📄 DiaryResponse 추가
- 단건 일기 조회 및 저장 응답 DTO
- 포함 필드:

```
Long id  
LocalDate date  
String diaryText  
boolean exists
fromEntity() 정적 팩토리 메서드 제공
```

## 📄 DiaryListResponse 추가
- 전체 일기 목록 조회 응답 DTO
- 포함 필드:

```
LocalDate date  
String diaryText
```

## ⚙️ DiaryController 수정
- @RequestBody Map → DiaryRequest 로 변경
- 응답을 DiaryResponse 및 DiaryListResponse 형태로 반환하도록 수정

## ⚙️ DiaryService 수정
- 엔티티를 직접 반환하던 로직을 DTO 기반으로 리팩터링
- 각 서비스 메서드 내에서 fromEntity()를 통해 변환 처리